### PR TITLE
Fix syntax error in settings-broken.tsx

### DIFF
--- a/client/src/pages/settings-broken.tsx
+++ b/client/src/pages/settings-broken.tsx
@@ -760,11 +760,10 @@ export default function Settings() {
                 </div>
               </CardContent>
             </Card>
-            </TabsContent>
-          )}
+          </TabsContent>
         </Tabs>
-        )}
-      </main>
-    </div>
+      )}
+    </main>
+  </div>
   );
 }


### PR DESCRIPTION
## Summary
- correct closing JSX blocks in `settings-broken.tsx`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npx tsc --noEmit client/src/pages/settings-broken.tsx` *(fails: Cannot find module ...)*

------
https://chatgpt.com/codex/tasks/task_e_6864a5c3bb98832fb8354433798fe689